### PR TITLE
Validate actor input schema

### DIFF
--- a/.actor/INPUT_SCHEMA.json
+++ b/.actor/INPUT_SCHEMA.json
@@ -66,13 +66,13 @@
             "properties": {
                 "minPrice": {
                     "title": "Min Price",
-                    "type": "number",
+                    "type": "integer",
                     "description": "Minimum price in local currency",
                     "minimum": 0
                 },
                 "maxPrice": {
                     "title": "Max Price",
-                    "type": "number",
+                    "type": "integer",
                     "description": "Maximum price in local currency",
                     "minimum": 0
                 },


### PR DESCRIPTION
Update `minPrice` and `maxPrice` schema types to `integer` to resolve Apify input schema validation errors.

The Apify platform's input schema validation expects numeric fields to be of type `integer` rather than `number`, which was causing the error: "Field schema.properties.filters.minPrice is not matching any input schema type definition."

---
<a href="https://cursor.com/background-agent?bcId=bc-33dca45e-3f19-4053-a389-c3fd8eb5072e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33dca45e-3f19-4053-a389-c3fd8eb5072e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

