### PR TITLE
Remove product per page from schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Extract products from H&M's global network with the most advanced scraper availa
 ### Performance Options
 ```json
 {
-    "productsPerPage": 128,
     "maxConcurrency": 10,
     "extractProductDetails": false,
     "enableProgressiveSaving": true
@@ -165,7 +164,6 @@ Extract products from H&M's global network with the most advanced scraper availa
 | **filters** | object | Product filters (see filtering options) | {} |
 | **maxProducts** | number | Maximum products to scrape | 100 |
 | **maxPages** | number | Maximum pages per category | 0 (unlimited) |
-| **productsPerPage** | number | Products per page (max 128) | 72 |
 | **sortBy** | string | Sort order | "stock" |
 | **includeVariants** | boolean | Include all color/size variants | true |
 | **extractProductDetails** | boolean | Visit product pages for full details | false |

--- a/src/main_v2.ts
+++ b/src/main_v2.ts
@@ -25,7 +25,6 @@ interface EnhancedInputSchema {
     // Scraping options
     maxProducts?: number;
     maxPages?: number;
-    productsPerPage?: number;
     sortBy?: 'stock' | 'newProduct' | 'ascPrice' | 'descPrice';
     includeVariants?: boolean;
     extractProductDetails?: boolean;
@@ -54,7 +53,6 @@ const {
     filters = {},
     maxProducts = 100,
     maxPages = 0,
-    productsPerPage = 72,
     sortBy = 'stock',
     includeVariants = true,
     extractProductDetails = false,
@@ -108,8 +106,7 @@ for (const category of categories) {
     
     const urlBuilder = new HMUrlBuilder(url)
         .applyFilters(filters)
-        .applySort({ sort: sortBy })
-        .applyPagination({ pageSize: productsPerPage });
+        .applySort({ sort: sortBy });
     
     urls.push({
         url: urlBuilder.build(),
@@ -125,7 +122,7 @@ for (const category of categories) {
 
 // 3. Generate search URLs
 for (const query of searchQueries) {
-    const searchUrl = `${baseUrl}/search-results/_jcr_content/search.display.json?q=${encodeURIComponent(query)}&page-size=${productsPerPage}`;
+    const searchUrl = `${baseUrl}/search-results/_jcr_content/search.display.json?q=${encodeURIComponent(query)}`;
     
     urls.push({
         url: searchUrl,


### PR DESCRIPTION
Remove `productsPerPage` from the input schema to simplify user configuration and rely on H&M's default pagination.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b1ff42a-ef2a-4874-be52-7b6431c84e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b1ff42a-ef2a-4874-be52-7b6431c84e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

