### PR TITLE
Fix invalid input schema enum property

### DIFF
--- a/.actor/INPUT_SCHEMA.json
+++ b/.actor/INPUT_SCHEMA.json
@@ -150,9 +150,8 @@
             "type": "integer",
             "description": "Number of products per page (higher = faster)",
             "default": 72,
-            "editor": "select",
-            "enum": [36, 72, 108, 128],
-            "enumTitles": ["36 (Default)", "72 (Fast)", "108 (Faster)", "128 (Fastest)"]
+            "minimum": 1,
+            "maximum": 200
         },
         "sortBy": {
             "title": "Sort Products By",


### PR DESCRIPTION
Fix input schema validation error by replacing the invalid `enum` property with `minimum` and `maximum` constraints for `productsPerPage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddaf19a3-ee88-4a8f-b1db-9631cc76b48f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ddaf19a3-ee88-4a8f-b1db-9631cc76b48f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

