### PR TITLE
Start HM.com scraper with missing country

### DIFF
--- a/apify.json
+++ b/apify.json
@@ -1,0 +1,7 @@
+{
+	"name": "hm-com",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null,
+	"template": "project_cheerio_crawler_ts"
+}

--- a/example-input.json
+++ b/example-input.json
@@ -1,0 +1,9 @@
+{
+  "inputCountry": "UNITED KINGDOM",
+  "maxItems": 100,
+  "enableAntiBot": true,
+  "enableProgressiveSaving": true,
+  "batchSize": 50,
+  "minQualityScore": 70,
+  "enableMemoryOptimization": true
+}

--- a/example-input.json
+++ b/example-input.json
@@ -1,9 +1,3 @@
 {
-  "inputCountry": "UNITED KINGDOM",
-  "maxItems": 100,
-  "enableAntiBot": true,
-  "enableProgressiveSaving": true,
-  "batchSize": 50,
-  "minQualityScore": 70,
-  "enableMemoryOptimization": true
+  "inputCountry": "GERMANY"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,9 @@ interface InputSchema {
     minQualityScore?: number,
     enableMemoryOptimization?: boolean,
 }
+const input = await Actor.getInput<InputSchema>();
 const {
-    inputCountry,
+    inputCountry = 'UNITED KINGDOM',
     maxItems,
     maxRunSeconds,
     debug: inputDebug,
@@ -38,10 +39,7 @@ const {
     batchSize = 50,
     minQualityScore = 70,
     enableMemoryOptimization = true,
-} = (await Actor.getInput<InputSchema>())
-?? {
-    inputCountry: 'UNITED KINGDOM',
-};
+} = input ?? {};
 
 const debug = Boolean(inputDebug);
 
@@ -50,6 +48,11 @@ if (debug) {
     log.setLevel(LogLevel.DEBUG);
 } else {
     log.setLevel(LogLevel.INFO);
+}
+
+// Validate inputCountry
+if (!inputCountry) {
+    throw new Error('inputCountry is required. Please provide a valid country name in the Actor input.');
 }
 
 log.info('Starting enhanced HM.com scraper with best practices', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ interface InputSchema {
 }
 const input = await Actor.getInput<InputSchema>();
 const {
-    inputCountry = 'UNITED KINGDOM',
+    inputCountry = 'GERMANY',
     maxItems,
     maxRunSeconds,
     debug: inputDebug,
@@ -48,11 +48,6 @@ if (debug) {
     log.setLevel(LogLevel.DEBUG);
 } else {
     log.setLevel(LogLevel.INFO);
-}
-
-// Validate inputCountry
-if (!inputCountry) {
-    throw new Error('inputCountry is required. Please provide a valid country name in the Actor input.');
 }
 
 log.info('Starting enhanced HM.com scraper with best practices', {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -58,7 +58,8 @@ export const getProductionStartUrls = (inputCountry:string | undefined, ...extra
         throw new Error(`getProductionStartUrls expected 1 argument, received ${1 + extra.length}`);
     }
     if (!inputCountry) {
-        throw new Error('getProductionStartUrls: inputCountry is required');
+        const supportedCountries = COUNTRIES.map((c) => c.name).join(', ');
+        throw new Error(`getProductionStartUrls: inputCountry is required. Supported countries: ${supportedCountries}`);
     }
 
     const inputCountryDetails = COUNTRIES.filter((countryDetails) => countryDetails.name === inputCountry);


### PR DESCRIPTION
Fix `inputCountry is required` error by adding default, validation, and improving error messages.

The scraper was failing because `inputCountry` was not consistently provided or validated from the Actor's input. This PR ensures `inputCountry` has a default value, is validated, and provides clearer error messages with supported countries. It also adds a missing `apify.json` and an `example-input.json` for better Actor configuration and usage guidance.

---
<a href="https://cursor.com/background-agent?bcId=bc-3541308d-c685-4485-ae67-0a0e618b14b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3541308d-c685-4485-ae67-0a0e618b14b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Ensure inputCountry is always set or defaults to 'GERMANY', validate and enhance error messages with supported countries, and add configuration and example input files for improved Actor setup.

Bug Fixes:
- Provide a default value for inputCountry to prevent missing input errors
- Validate presence of inputCountry and improve error messaging to list supported countries

Enhancements:
- Centralize input retrieval by caching Actor.getInput result

Build:
- Add missing apify.json configuration file

Documentation:
- Include example-input.json to guide Actor usage