### PR TITLE
Fix scraper config navigationtimeoutsecs

### DIFF
--- a/src/anti_bot.ts
+++ b/src/anti_bot.ts
@@ -200,7 +200,7 @@ export const getAntiBotCrawlerConfig = (baseConfig: Partial<CheerioCrawlerOption
 
         // Request configuration
         requestHandlerTimeoutSecs: 120, // Increased timeout for complex interactions
-        requestTimeoutSecs: 60, // Increased HTTP request timeout to handle slow responses
+        navigationTimeoutSecs: 60, // Increased navigation timeout to handle slow responses
         maxRequestRetries: 7, // Increased retries with advanced backoff
 
         // Anti-bot evasion


### PR DESCRIPTION
Change `requestTimeoutSecs` to `navigationTimeoutSecs` to fix an `ArgumentError` in `HttpCrawlerOptions`.

The property `requestTimeoutSecs` is not valid for `HttpCrawlerOptions`, leading to an `ArgumentError`. This PR corrects the property name to `navigationTimeoutSecs`, which is the appropriate setting for handling slow responses during navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-81c6c08f-9663-4f53-aa7c-e440268c2928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81c6c08f-9663-4f53-aa7c-e440268c2928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Bug Fixes:
- Replace invalid requestTimeoutSecs with navigationTimeoutSecs in crawler config